### PR TITLE
Fix quotes and backticks in deploy commit msg

### DIFF
--- a/.github/workflows/deploy.yml
+++ b/.github/workflows/deploy.yml
@@ -31,10 +31,8 @@ jobs:
       shell: bash
 
     - name: Parse commit title
-      continue-on-error: true # Temp step until backticks and quotes in commit messages are fixed
       run: |
-        COMMIT_MSG="${{ github.event.head_commit.message }}"
-        echo "COMMIT_TITLE=${COMMIT_MSG%%$'\n'*}" >> $GITHUB_ENV
+        echo "COMMIT_TITLE=$(echo '${{ github.event.head_commit.message }}' | head -1 | sed 's/\"/\\"/g')" >> $GITHUB_ENV
 
     - name: Configure AWS credentials
       uses: aws-actions/configure-aws-credentials@v1


### PR DESCRIPTION
Proof it works: https://github.com/outfunnel/api/runs/8246583550?check_suite_focus=true
And https://outfunnel.slack.com/archives/CAGEASZL4/p1662631161530759