### PR TITLE
Added action to publish npm packages

### DIFF
--- a/.github/workflows/npmtest.yml
+++ b/.github/workflows/npmtest.yml
@@ -30,7 +30,7 @@ jobs:
       with:
         node-version: '${{ steps.nvm.outputs.NVMRC }}'
 
-    - run: npm ci
+    - run: npm ci || npm install
     - run: npm run lint --if-present
     - run: npm run build --if-present
     - run: npm test --if-present

--- a/.github/workflows/publish.yml
+++ b/.github/workflows/publish.yml
@@ -33,6 +33,7 @@ jobs:
         node-version: '${{ steps.nvm.outputs.NVMRC }}'
 
     - run: npm ci || npm install
+    - run: npm run build --if-present
 
     - name: Publish the library
       run: npm publish

--- a/.github/workflows/publish.yml
+++ b/.github/workflows/publish.yml
@@ -32,6 +32,8 @@ jobs:
       with:
         node-version: '${{ steps.nvm.outputs.NVMRC }}'
 
+    - run: npm ci || npm install
+
     - name: Publish the library
       run: npm publish
 

--- a/.github/workflows/publish.yml
+++ b/.github/workflows/publish.yml
@@ -1,0 +1,43 @@
+on:
+  workflow_call:
+
+name: Publish and tag npm package
+
+jobs:
+  publish:
+    name: Publish
+    runs-on: ubuntu-latest
+    env:
+      NODE_ENVIRONMENT: "production"
+
+    steps:
+    - name: Checkout
+      uses: actions/checkout@v3
+
+    - name: Set up Outfunnel Registry
+      run: |
+        echo "@outfunnel:registry=https://${{ secrets.OF_REGISTRY_HOST }}/" > .npmrc
+        echo "//${{ secrets.OF_REGISTRY_HOST }}/:_authToken=${{ secrets.OF_REGISTRY_TOKEN }}" >> .npmrc
+
+    - name: Read .nvmrc
+      run: echo ::set-output name=NVMRC::$(cat .nvmrc)
+      id: nvm
+
+    - name: Read target version
+      run: echo ::set-output name=VERSION::$(node -p "require('./package.json').version")
+      id: version
+
+    - name: Setup node
+      uses: actions/setup-node@v3
+      with:
+        node-version: '${{ steps.nvm.outputs.NVMRC }}'
+
+    - run: npm ci
+
+    - name: Publish the library
+      run: npm publish
+
+    - name: Push tag to git
+      run: |
+        git tag "v${{ steps.version.outputs.VERSION }}"
+        git push --tags

--- a/.github/workflows/publish.yml
+++ b/.github/workflows/publish.yml
@@ -32,8 +32,6 @@ jobs:
       with:
         node-version: '${{ steps.nvm.outputs.NVMRC }}'
 
-    - run: npm ci
-
     - name: Publish the library
       run: npm publish
 


### PR DESCRIPTION
This allows to migrate away from Codeship for publishing the packages.
Also it will tag the commit with the version, _after_ the merge to master. Now tags will be on master. I'll show the usage in `logger` after this is merged, but draft PR looks like this: https://github.com/outfunnel/logger/pull/24/files

The jobs output is like this: https://github.com/outfunnel/logger/actions/runs/3045749642/jobs/4907690703