### PR TITLE
Create multi-arch builds for docker

### DIFF
--- a/.github/workflows/deploy.yml
+++ b/.github/workflows/deploy.yml
@@ -77,7 +77,7 @@ jobs:
         docker buildx build \
         --tag $ECR_REGISTRY/$ECR_REPOSITORY:$IMAGE_TAG \
         --tag $ECR_REGISTRY/$ECR_REPOSITORY:latest \
-        --platform linux/arm64 \
+        --platform linux/arm64,linux/amd64 \
         --output type=image,push=true .
 
         echo "::set-output name=image::$ECR_REGISTRY/$ECR_REPOSITORY:$IMAGE_TAG"


### PR DESCRIPTION
This will allow us to schedule outfunnel pods on underutilised x86 nodes as well 