### PR TITLE
Use correct node env name

### DIFF
--- a/.github/workflows/publish.yml
+++ b/.github/workflows/publish.yml
@@ -14,7 +14,7 @@ jobs:
     name: Publish
     runs-on: ubuntu-latest
     env:
-      NODE_ENVIRONMENT: "production"
+      NODE_ENV: "production"
 
     steps:
     - name: Checkout


### PR DESCRIPTION
- We use `NODE_ENV` not `NODE_ENVIRONMENT`
- Caused some packages not to build well e.g `@outfunnel/email-editor`