### PR TITLE
Include devDependencies

### DIFF
--- a/.github/workflows/publish.yml
+++ b/.github/workflows/publish.yml
@@ -44,7 +44,7 @@ jobs:
       with:
         node-version: '${{ steps.nvm.outputs.NVMRC }}'
 
-    - run: npm ci || npm install
+    - run: npm ci --include=dev || npm install
     - run: npm run build --if-present
 
     - name: Publish the library

--- a/.github/workflows/publish.yml
+++ b/.github/workflows/publish.yml
@@ -44,7 +44,11 @@ jobs:
       with:
         node-version: '${{ steps.nvm.outputs.NVMRC }}'
 
-    - run: npm ci --include=dev || npm install
+    - name: Install dependencies
+      run: npm ci || npm install
+      env:
+        NODE_ENV: development
+        
     - run: npm run build --if-present
 
     - name: Publish the library


### PR DESCRIPTION
- npm ci ignores devDependencies when NODE_ENV is production
- We don't correctly make the right distinct in most of our packages
- Mini fix